### PR TITLE
Add simple RAG demo notebook

### DIFF
--- a/notebooks/simple_rag_example.ipynb
+++ b/notebooks/simple_rag_example.ipynb
@@ -1,0 +1,91 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Simple Retrieval-Augmented Generation (RAG) Example"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "This notebook demonstrates building a minimal RAG pipeline using LangChain. We'll index a few documents, retrieve them based on a query, and then generate an answer with an LLM."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Install required packages if running locally\n",
+        "%pip install langchain faiss-cpu --quiet"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from langchain.embeddings import HuggingFaceEmbeddings\n",
+        "from langchain.vectorstores import FAISS\n",
+        "from langchain.chat_models import ChatOpenAI\n",
+        "from langchain.chains import RetrievalQA\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Example documents\n",
+        "documents = [\n",
+        "    'RAG stands for retrieval augmented generation.',\n",
+        "    'It combines information retrieval with text generation.',\n",
+        "    'RAG is useful for question answering over private data.'\n",
+        "]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Create embeddings and vector store\n",
+        "embeddings = HuggingFaceEmbeddings()\n",
+        "vector_store = FAISS.from_texts(documents, embedding=embeddings)\n",
+        "retriever = vector_store.as_retriever()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "llm = ChatOpenAI(temperature=0)\n",
+        "qa = RetrievalQA.from_chain_type(llm=llm, chain_type='stuff', retriever=retriever)\n",
+        "result = qa.run('What does RAG stand for?')\n",
+        "print(result)"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `simple_rag_example.ipynb` showing how to build a minimal retrieval augmented generation pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dc1b5a554832290aece1410950685